### PR TITLE
column model concept; new sorting; various fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ pom.xml
 .lein-plugins/
 .repl
 .nrepl-port
+reagent-table.iml
+.idea/
+

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Reagent-table
 
 A table component with all the usual features you would expect.
 
-- Sort rows
+- Sort rows by multiple columns
 - Resizable columns
 - Re-order columns
 - Hide/show columns
@@ -13,8 +13,8 @@ A table component with all the usual features you would expect.
 	alt="Reagent-table"/>
 
 
-Contrarily to most React.js table components, this one use the correct
-HTML tags (table, theader, th, tr...) to be compatible with your
+Contrary to most React.js table components, this one uses the correct
+HTML tags (table, thead, th, tr...) to be compatible with your
 favorite CSS. This also means the data can easily be copied from the
 table.
 
@@ -33,51 +33,64 @@ Require Reagent-table in your namespace:
 
 Then, simply use it as a normal component:
 ```clj
-[rt/reagent-table table-data]
+[rt/reagent-table table-data config]
 ```
 
-`table-data` can be raw data, or data in an atom. **If an atom is
-provided, all manipulation will change the data directly inside the atom**.
+`table-data` is an atom containing a vector, each child being a row. How this data is rendered is determined by
+the `:column-model` and `:render-cell` configuration elements. `config` is a map containing various
+options described below.
 
-(If it doesn't match how your atom is built, take a look at
-[entanglement](https://github.com/Frozenlock/entanglement) to bridge
-the two.)
+There is a distinction between view and model coordinates for
+column numbers. A column's view position may change if it is
+reordered, whereas its model position will be that of its index
+into `:column-model`
 
-The data must be a map containing at least the following two keys:
-- `:headers`
-- `:rows`
+`:column-model` is a vector of so-called render-info maps containing
+- `:header` A string for the header cell text
+- `:key` The reagent key for the column position in any rows. If
+absent defaults to the model index
+- `:sortable false` When `:sort` is present (see below) by default all
+columns are sortable. Otherwise any column can be excluded and no
+glyph will appear in its header.
+Other entries are as required by the client. The map is passed to
+the `:render-cell` function when cells are painted.
 
+`:render-cell` a function that returns the hiccup for a table cell
+`(fn [render-info row row-num col-num] (...))`
+where `render-info` is the column entry, `row` is the vector child from
+`data-atom`, `row-num` is the row number and `col-num` is the column number
+in model coordiates.
 
-For example:
-```clj
-{:headers ["Row 1" "Row 2" "Row 3" "Row 4"]}
-```
+`:table-state` an atom used to hold table internal state. If supplied by
+the client this is a way to see table state at the repl, and to allow the
+client to modify column order and sorting state.
 
-The cells could also be reagent component:
-```clj
-{:headers [[:span "Row 1"]
-	       [:span "Row 2"]
-		   [:span "Row 3"]
-		   [:span "Row 4"]]}
-```
+`:row-key` A function that returns a value to be used as the regaent key
+for rows
+`(fn [row row-num] (...))`
+where `row` is the vector child from `data-atom`, `row-num` is the row number.
 
-`:rows` is similar, but should be a collection of rows, instead of a single row like `:headers`.
+`:sort` a function to sort `data-atom` when a header cell sort arrow is clicked.
+Returns the newly sorted vector. If absent, the table is not sortable and no
+glyphs appear in the header.
+`(fn [rows column-model sorting] (...))`
+where `rows` is the vector to sort, `column-model` is the `:column-model` and `sorting`
+is a vector of vectors of the form `[column-model-index :asc|:desc]`. If the
+column-model entry includes `:sortable false` the individual column is excluded
+from sorting. Select multiple columns for sorting by using ctrl-click. Repeat
+to toggle the sort direction.
 
-When using reagent components as cells, you can add the `:data`
-metadata to each of them. This is the value that will be used when
-sorting the columns.
+`:table` The attributes applied to the `[:table ... ]` element. Defaults
+to `{:style {:width nil}}}`
 
+`:thead` the attributes applied to `[:thead ...]`
 
-See `reagent-table.dev` for a simple working example.
+`:tbody` the attributes applied to `[:tbody ...]`
 
+`:caption` an optional hiccup form for a caption
 
-### Hide/Show Columns
+`:column-selection` optional attributes to display visible column toggles
+for example `{:ul {:li {:class "btn"}}}`
 
-To activate, set the value `:rows-selection` to non-nil in the
-optional config argument.
-
-### Table Caption
-
-Set the value `:caption` to the text value or the component to be used
-as the caption.
+See `reagent-table.dev` for a working example.
 

--- a/dev/reagent_table/dev.cljs
+++ b/dev/reagent_table/dev.cljs
@@ -1,24 +1,230 @@
 (ns ^:figwheel-always reagent-table.dev
-    (:require [reagent.core :as r]
-              [reagent-table.core :as rt]
-              [goog.events :as events]))
+  (:require [reagent.core :as r :refer [atom]]
+            [reagent-table.core :as rt]
+            [goog.events :as events]
+            [goog.i18n.NumberFormat.Format])
+  (:import
+    (goog.i18n NumberFormat)
+    (goog.i18n.NumberFormat Format)))
 
 (enable-console-print!)
 
+(def nff (NumberFormat. Format/DECIMAL))
+
+(defn format-number
+  [num]
+  (.format nff (str num)))
+
 ;; generate some dummy data
-(def table-data {:headers ["Row 1" "Row 2" "Row 3" "Row 4"]
-                         ;:rows [["Row 1" "Row 2" "Row 3" "Row 4"]
+(def table-data (r/atom
+                  [{:Animal {:Name    "Lizard"
+                             :Colour  "Green"
+                             :Skin    "Leathery"
+                             :Weight  100
+                             :Age     10
+                             :Hostile false}}
+                   {:Animal {:Name    "Lion"
+                             :Colour  "Gold"
+                             :Skin    "Furry"
+                             :Weight  190000
+                             :Age     4
+                             :Hostile true}}
+                   {:Animal {:Name    "Giraffe"
+                             :Colour  "Green"
+                             :Skin    "Hairy"
+                             :Weight  1200000
+                             :Age     8
+                             :Hostile false}}
+                   {:Animal {:Name    "Cat"
+                             :Colour  "Black"
+                             :Skin    "Furry"
+                             :Weight  5500
+                             :Age     6
+                             :Hostile false}}
+                   {:Animal {:Name    "Capybara"
+                             :Colour  "Brown"
+                             :Skin    "Hairy"
+                             :Weight  45000
+                             :Age     12
+                             :Hostile false}}
+                   {:Animal {:Name    "Bear"
+                             :Colour  "Brown"
+                             :Skin    "Furry"
+                             :Weight  600000
+                             :Age     10
+                             :Hostile true}}
+                   {:Animal {:Name    "Rabbit"
+                             :Colour  "White"
+                             :Skin    "Furry"
+                             :Weight  1000
+                             :Age     6
+                             :Hostile false}}
+                   {:Animal {:Name    "Fish"
+                             :Colour  "Gold"
+                             :Skin    "Scaly"
+                             :Weight  50
+                             :Age     5
+                             :Hostile false}}
+                   {:Animal {:Name    "Hippo"
+                             :Colour  "Grey"
+                             :Skin    "Leathery"
+                             :Weight  1800000
+                             :Age     10
+                             :Hostile false}}
+                   {:Animal {:Name    "Zebra"
+                             :Colour  "Black/White"
+                             :Skin    "Hairy"
+                             :Weight  200000
+                             :Age     9
+                             :Hostile false}}
+                   {:Animal {:Name    "Squirrel"
+                             :Colour  "Grey"
+                             :Skin    "Furry"
+                             :Weight  300
+                             :Age     1
+                             :Hostile false}}
+                   {:Animal {:Name    "Crocodile"
+                             :Colour  "Green"
+                             :Skin    "Leathery"
+                             :Weight  500000
+                             :Age     10
+                             :Hostile true}}]))
 
-                 :rows (take 20 (partition 4 (repeatedly (fn [] [:span (rand-nth (range 5000000000000000))]))))})
+;the column model
+(def columns [{:path [:Animal :Name]
+               :header "Name"
+               :key :Name}  ; convention - use field name for reagent key
+              {:path [:Animal :Colour]
+               :header "Colour"
+               :key :Colour}
+              {:path [:Animal :Skin]
+               :header "Skin Type"
+               :key :Skin}
+              {:path [:Animal :Weight]
+               :header "Weight"
+               :format #(format-number %)
+               :attrs (fn [data] {:style {:text-align "right"
+                                          :display "block"}})
+               :key :Weight}
+              {:path [:Animal :Age]
+               :header "Age"
+               :attrs (fn [data] {:style {:text-align "right"
+                                          :display "block"}})
+               :key :Age}
+              {:path [:Animal :Hostile]
+               :header "Hostile?"
+               :format #(if % "Stay Away!" "OK to stroke")
+               :key :Hostile}])
 
+(defn- row-key-fn
+  "Return the reagent row key for the given row"
+  [row row-num]
+  (get-in row [:Animal :Name]))
+
+(defn- cell-data
+  "Resolve the data within a row for a specific column"
+  [row cell]
+  (let [{:keys [path expr]} cell]
+    (or (and path
+             (get-in row path))
+        (and expr
+             (expr row)))))
+
+(defn- cell-fn
+"Return the cell hiccup form for rendering.
+ - render-info the specific column from :column-model
+ - row the current row
+ - row-num the row number
+ - col-num the column number in model coordinates"
+[render-info row row-num col-num]
+(let [{:keys [format attrs]
+       :or   {format identity
+              attrs (fn [_] {})}} render-info
+      data    (cell-data row render-info)
+      content (format data)
+      attrs   (attrs data)]
+  [:span
+   attrs
+   content]))
+
+(defn date?
+  "Returns true if the argument is a date, false otherwise."
+  [d]
+  (instance? js/Date d))
+
+(defn date-as-sortable
+  "Returns something that can be used to order dates."
+  [d]
+  (.getTime d))
+
+(defn compare-vals
+  "A comparator that works for the various types found in table structures.
+  This is a limited implementation that expects the arguments to be of
+  the same type. The :else case is to call compare, which will throw
+  if the arguments are not comparable to each other or give undefined
+  results otherwise.
+
+  Both arguments can be a vector, in which case they must be of equal
+  length and each element is compared in turn."
+  [x y]
+  (cond
+    (and (vector? x)
+         (vector? y)
+         (= (count x) (count y)))
+    (reduce #(let [r (compare (first %2) (second %2))]
+               (if (not= r 0)
+                 (reduced r)
+                 r))
+            0
+            (map vector x y))
+
+    (or (and (number? x) (number? y))
+        (and (string? x) (string? y))
+        (and (boolean? x) (boolean? y)))
+    (compare x y)
+
+    (and (date? x) (date? y))
+    (compare (date-as-sortable x) (date-as-sortable y))
+
+    :else ;; hope for the best... are there any other possiblities?
+    (compare x y)))
+
+(defn- sort-fn
+  "Generic sort function for tabular data. Sort rows using data resolved from
+  the specified columns in the column model."
+  [rows column-model sorting]
+  (sort (fn [row-x row-y]
+          (reduce
+            (fn [_ sort]
+              (let [column (column-model (first sort))
+                    direction (second sort)
+                    cell-x (cell-data row-x column)
+                    cell-y (cell-data row-y column)
+                    compared (if (= direction :asc)
+                               (compare-vals cell-x cell-y)
+                               (compare-vals cell-y cell-x))]
+                (when-not (zero? compared)
+                  (reduced compared))
+                ))
+            0
+            sorting))
+        rows))
+
+(def table-state (atom {:draggable true}))
 
 (r/render-component 
  [:div.container {:style {:font-size 16 :margin-top 10}}
-  [:div.panel.panel-default
-   [:div.panel-body
-    [rt/reagent-table table-data {:table 
-                                  {:class "table table-hover table-striped table-bordered table-transition"}
+  ;[:div.panel.panel-default
+   ;[:div.panel-body
+    [rt/reagent-table table-data {:table {:class "table table-hover table-striped table-bordered table-transition"}
+                                  :table-state  table-state
+                                  :column-model columns
+                                  :row-key      row-key-fn
+                                  :render-cell  cell-fn
+                                  :sort         sort-fn
                                   :caption [:caption "Test caption"]
-                                  :rows-selection {:ul
-                                                   {:li {:class "btn"}}}}]]]]
+                                  :column-selection {:ul
+                                                   {:li {:class "btn"}}}
+                                  }]]
+;]]
  (. js/document (getElementById "app")))

--- a/project.clj
+++ b/project.clj
@@ -1,15 +1,15 @@
-(defproject org.clojars.frozenlock/reagent-table "0.1.3"
+(defproject org.clojars.frozenlock/reagent-table "0.1.4-SNAPSHOT"
   :description "FIXME: write this!"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/clojurescript "0.0-3211"]
-                 [reagent "0.5.0-alpha3"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.clojure/clojurescript "1.9.671"]
+                 [reagent "0.7.0"]]
 
-  :plugins [[lein-cljsbuild "1.0.5"]
-            [lein-figwheel "0.3.1"]]
+  :plugins [[lein-cljsbuild "1.1.5"]
+            [lein-figwheel "0.5.11"]]
 
   :source-paths ["src"]
 

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -3,6 +3,7 @@
   <head>
     <!-- <link href="css/bootstrap-dark.min.css" rel="stylesheet" type="text/css"> -->
     <link href="css/style.css" rel="stylesheet" type="text/css">
+    <link href="css/bootstrap-dark.min.css" rel="stylesheet" type="text/css">
   </head>
   <body>
     <div id="app">

--- a/src/reagent_table/core.cljs
+++ b/src/reagent_table/core.cljs
@@ -7,19 +7,17 @@
 ;;; Does it work? Yup!
 ;;; Do I have time to clean it up? Not really...
 
-
-
-(defn drag-move-fn [on-drag]
+(defn- drag-move-fn [on-drag]
   (fn [evt]
     (.preventDefault evt) ;; otherwise we select text while resizing
     (on-drag (.-clientX evt) (.-clientY evt))))
 
-(defn drag-end-fn [drag-move drag-end]
+(defn- drag-end-fn [drag-move drag-end]
   (fn [evt]
     (events/unlisten js/window EventType.MOUSEMOVE drag-move)
     (events/unlisten js/window EventType.MOUSEUP @drag-end)))
 
-(defn dragging [on-drag]
+(defn- dragging [on-drag]
   (let [drag-move (drag-move-fn on-drag)
         drag-end-atom (atom nil)
         drag-end (drag-end-fn drag-move drag-end-atom)]
@@ -29,46 +27,64 @@
   
 
 
-(defn recursive-merge
+(defn- recursive-merge
   "Recursively merge hash maps."
   [a b]
   (if (and (map? a) (map? b))
     (merge-with recursive-merge a b)
     b))
 
+(defn- column-index-to-model
+  "Convert the given column in view coordinates to
+  model coordinates."
+  [state-atom view-col]
+  (-> @state-atom
+      :col-index-to-model
+      (nth view-col)))
 
-(defn sort-fn
-  [rows column ascending?]
-  (let [sorted (sort-by (fn [r] 
-                          (let [cell (nth r column)]
-                            (get (meta cell) :data cell))) rows)]
-    (if ascending? sorted (rseq sorted))))
+(defn- reorder-column-index-to-model!
+  "Maintain the column-index-to-model mapping after
+  view reordering. The arguments are the drag and drop
+  columns, in view coordinates."
+  [drag-col drop-col state-atom]
+  (let [cur          (:col-index-to-model @state-atom)
+        lower-bound  (min drag-col drop-col)
+        upper-bound  (max drag-col drop-col)
+        direction    (if (< drag-col drop-col) :right :left)
+        moving-model (column-index-to-model state-atom drag-col)]
+    ;(.log js/console (str "drag-col: " drag-col))
+    ;(.log js/console (str "drop-col: " drop-col))
+    (swap! state-atom
+           assoc :col-index-to-model
+                 (into []
+                       (map-indexed
+                         (fn [view-col model-col]
+                           (cond (= view-col drop-col)
+                                 (cur drag-col)
+
+                                 (or (< view-col lower-bound)
+                                     (> view-col upper-bound))
+                                 (cur view-col)
+
+                                 (and (>= view-col lower-bound)
+                                      (= direction :right))
+                                 (cur (inc view-col))
+
+                                 (and (<= view-col upper-bound)
+                                      (= direction :left))
+                                 (cur (dec view-col))))
+                         cur)))))
 
 (def default-configs {:table
-                      {:style {:width nil}
-                       :thead
-                       {:tr
-                        {
-                         :th
-                         {:style {;:transition "all 0.2s ease-in-out;"
-                                  ;; :-moz-user-select "none"
-                                  ;; :-webkit-user-select "none"
-                                  ;; :-ms-user-select "none"
-                                  }}}}}})
+                      {:style {:width nil}}})
+                       ;:thead {:tr {:th {:style
+                       ;                  {;:transition "all 0.2s ease-in-out;"
+                       ;                   ;; :-moz-user-select "none"
+                       ;                   ;; :-webkit-user-select "none"
+                       ;                   ;; :-ms-user-select "none"
+                       ;                   }}}}}})
 
-(defn reorder-column! [source-atom c1 c2]
-  (let [swap-vec (fn [v i1 i2]
-                   (let [v (vec v)]
-                     (assoc v i2 (nth v i1) i1 (nth v i2))))
-        source @source-atom
-        updated-source (-> source
-                           (update-in [:headers] swap-vec c1 c2)
-                           (update-in [:rows] (fn [s] (mapv #(swap-vec % c1 c2) s))))]
-    (reset! source-atom updated-source)))
-    
-
-
-(defn resize-widget [cell-container]
+(defn- resize-widget [cell-container]
   [:span {:style {:display "inline-block"
                   :width "8"
                   :position "absolute"
@@ -87,97 +103,156 @@
                                (aset cell-node "width" (- init-width (- init-x x)))))
                             (.preventDefault %))}])
 
+(defn- update-sort-columns!
+  "Maintain multiple sort columns each with individual directions. The
+  column numbers are in model coordinates.
 
-(defn header-cell-fn [i n configs source-atom state-atom]
-  (let [
-        state @state-atom
-        col-hidden (:col-hidden state)
-        col-state-a (r/cursor state-atom [:col-state n])
-        sort-click-fn (fn []
-                        (let [sorting (-> (swap! state-atom update-in [:sorting]
-                                                 #(if-not (= [n :asc] %)
-                                                    [n :asc]
-                                                    [n :desc]))
-                                          (get-in [:sorting 1]))]
-                          (swap! source-atom update-in [:rows]
-                                 sort-fn n (= sorting :asc))))]
+  A column is initially set to ascending order and toggled thereafter.
+  If a column is not present in list it is appended or becomes the only
+  element when 'append' is false."
+  [model-col state-atom append]
+  (let [sorting (:sorting @state-atom)]
+    (swap! state-atom
+           assoc :sorting
+           (if-not append
+             [[model-col (if (= (first sorting) [model-col :asc]) :desc :asc)]]
+             (loop [sorting sorting
+                    found false
+                    result []]
+               (let [column (first sorting)
+                     this-col (first column)
+                     this-dir (second column)]
+                 (if column
+                   (if (= model-col this-col)
+                     (recur (rest sorting)
+                            true
+                            (conj result [model-col (if (= this-dir :asc) :desc :asc)]))
+                     (recur (rest sorting)
+                            found
+                            (conj result column)))
+                   (if found
+                     result
+                     (conj result [model-col :asc])))))))))
+
+(defn- is-sorting
+  "Return the sort direction for the specified column number, nil
+  if the column is not currently sorted, or :none if the column is not
+  sortable at all. Column number must be in model coordinates."
+  [sorting render-info model-col]
+  (if (false? (:sortable render-info))
+    :none
+    (-> (filter #(= (first %) model-col)
+                sorting)
+        first
+        second)))
+
+(defn header-cell-fn [render-info
+                      view-col
+                      model-col
+                      configs
+                      state-atom
+                      data-atom]
+  (let [state         @state-atom
+        col-hidden    (:col-hidden state)
+        {:keys [draggable]} state
+        sort-fn       (:sort configs)
+        column-model  (:column-model configs)
+        sortable      (not (false? (:sortable render-info)))
+        sort-click-fn (fn [append]
+                        (when sort-fn
+                          (swap! data-atom assoc :rows (sort-fn (:rows @data-atom)
+                                   column-model
+                                   (:sorting (update-sort-columns! model-col state-atom append)))))
+                        (.log js/console (str "append: " append))
+                        (.log js/console (str "sorting: " (:sorting @state-atom)))
+                        )]
     [:th
-     (recursive-merge 
-      (get configs :th)
+     (recursive-merge
+      (:th configs)
       {;:width (str (get @col-state-a :width) "px") ;; <--------
-       :draggable true
+       :draggable draggable
        :on-drag-start #(do (doto (.-dataTransfer %)
                              (.setData "text/plain" "")) ;; for Firefox
                            (swap! state-atom assoc :col-reordering true))
-       :on-drag-over #(swap! state-atom assoc :col-hover n)
+       :on-drag-over #(swap! state-atom assoc :col-hover view-col)
        :on-drag-end #(let [col-hover (:col-hover @state-atom)
                            col-sorting (first (get @state-atom :sorting))]
-                       (when-not (= n col-hover) ;; if dropped on another column
-                         (reorder-column! source-atom n col-hover)
-                         (when (some #{col-sorting} [n col-hover])
+                       (when-not (= view-col col-hover) ;; if dropped on another column
+                         (reorder-column-index-to-model! view-col col-hover state-atom)
+                         ;(reorder-column! data-atom view-col col-hover)
+                         (comment (when (some #{col-sorting} [view-col col-hover])
                            ;; if any of them is currently sorted
                            (swap! state-atom update-in
                                   [:sorting]
                                   (fn [[col-n sort-type]]
-                                    [(if (= col-n n) col-hover n) sort-type]))))
-                       (swap! state-atom assoc 
+                                    [(if (= col-n view-col) col-hover view-col) sort-type])))))
+                       (swap! state-atom assoc
                               :col-hover nil
                               :col-reordering nil))
        :style (merge {:position "relative"
-                      :cursor "move"
-                      :display (when (get col-hidden n) "none")}
+                      :cursor (if draggable "move" nil)
+                      :display (when (get col-hidden view-col) "none")}
                      (when (and (:col-reordering state)
-                                (= n (:col-hover state)))
+                                (= view-col (:col-hover state)))
                        {:border-right "6px solid #3366CC"}))})
-     [:span {:style {:padding-right 50}} i]
-     [:span {:style {:position "absolute"
-                     :text-align "center"
-                     :height "1.5em"
-                     :width "1.5em"
-                     :right "15px"
-                     :cursor "pointer"}
-             :on-click sort-click-fn}
-      (condp = (get state :sorting)
-        [n :asc] " ▲" 
-        [n :desc] " ▼"
-        ;; and to occupy the same space...
-        [:span {:style {:opacity "0.3"}}
-         " ▼"])]
+     [:span {:style {:padding-right 50}} (:header render-info)]
+     (when (and sort-fn sortable)
+       [:span {:style {:position "absolute"
+                       :text-align "center"
+                       :height "1.5em"
+                       :width "1.5em"
+                       :right "15px"
+                       :cursor "pointer"}
+               :on-click #(sort-click-fn (.-ctrlKey %))}
+        (condp = (is-sorting (:sorting state) render-info model-col)
+          :asc " ▲"
+          :desc " ▼"
+          :none nil
+          ;; sortable but not participating
+          [:span {:style {:opacity "0.3"}}
+           " ▼"])])
      [resize-widget (r/current-component)]]))
 
 
-(defn header-row-fn [items configs source-atom state-atom]
+(defn header-row-fn [column-model configs data-atom state-atom]
   (let [state @state-atom]
     [:tr
-     (for [[n i] (map-indexed (fn [& args] args) items)]
-       ^{:key n}
-       [header-cell-fn i n configs source-atom state-atom])]))
+     (doall (map-indexed (fn [view-col _]
+                           (let [model-col (column-index-to-model state-atom view-col)
+                                 render-info (column-model model-col)]
+                              ^{:key (or (:key render-info) model-col)}
+                              [header-cell-fn render-info view-col model-col configs state-atom data-atom]))
+                         column-model))]))
 
 
-(defn row-fn [item state-atom]
-  (let [comp (r/current-component)
-        state @state-atom
-        col-hidden (:col-hidden state)]
-  [:tr ;; {:draggable true
-       ;;  :on-drag-start #(do (doto (.-dataTransfer %)
-       ;;                        (.setData "text/plain" "") ;; for Firefox
-       ;;                        ))}
-   (doall
-    (map-indexed (fn [n i]
-                   ^{:key n}
-                   [:td {:on-drag-over #(swap! state-atom assoc :col-hover n)
-                         :style {:border-right (when (and (:col-reordering state)
-                                                          (= n (:col-hover state)))
-                                                 "2px solid #3366CC")
-                                 :display (when (get col-hidden n) "none")}}
-                    i]) item))]))
+(defn row-fn [row row-num row-key-fn state-atom config]
+  (let [state @state-atom
+        col-hidden (:col-hidden state)
+        col-key-fn (:col-key config (fn [row row-num col-num] col-num))
+        col-model  (:column-model config)
+        cell-fn    (:cell config (fn [cell row row-num col-num] cell))]
+    ^{:key (row-key-fn row row-num)}
+    [:tr
+     (doall
+       (map-indexed (fn [view-col _]
+                      (let [model-col (column-index-to-model state-atom view-col)]
+                        ^{:key (col-key-fn row row-num model-col)}
+                        [:td
+                         {:style  {:border-right (when (and (:col-reordering state)
+                                                            (= view-col (:col-hover state)))
+                                                             "2px solid #3366CC")
+                                   :display      (when (get col-hidden view-col) "none")}}
+                         (cell-fn (col-model model-col) row row-num model-col)]))
+                    (or
+                      col-model
+                      row)))]))
   
-(defn rows-fn [rows state-atom]
-  (let [comp (r/current-component)]
-    (doall (map-indexed
-            (fn [n i]
-              ^{:key n}
-              [row-fn i state-atom]) rows))))
+(defn rows-fn [rows state-atom config]
+  (let [row-key-fn (:row-key config (fn [row row-num] row-num))]
+  (doall (map-indexed
+           (fn [row-num row]
+             (row-fn row row-num row-key-fn state-atom config))
+           rows))))
 
 
 
@@ -197,7 +272,10 @@
               li-config)
          i " "(if @hidden-a "☐" "☑")]))]))
 
-
+(defn- init-column-index
+  "Set up in the initial column-index-to-model numbers"
+  [headers]
+  (into [] (map-indexed (fn [idx _] idx) headers)))
 
 (defn reagent-table
   "Optional properties map include :table :thead and :tbody.
@@ -209,12 +287,12 @@
          data-atom (if-not (satisfies? IAtom data-or-data-atom)
                      (r/atom data-or-data-atom)
                      data-or-data-atom)                    
-         state-atom (r/atom {})] ;; a place for the table local state
-     (assert (let [data @data-atom]
-               (and (:headers data)
-                    (:rows data)))
+         state-atom (or (:table-state table-configs) (r/atom {})) ;; a place for the table local state
+         {:keys [headers rows]} @data-atom]
+     (assert (and headers rows)
              "Missing :headers or :rows in the provided data.")
-                   
+     ; TODO cursors or something to separate headers from rows so we can reinitialise column indexes only when headers change
+     (swap! state-atom #(assoc % :col-index-to-model (init-column-index (:rows-selection table-configs))))
      (fn []
        (let [data @data-atom]
          [:div
@@ -222,16 +300,15 @@
                        ".reagent-table * td { max-width: 3px;"
                        "overflow: hidden;text-overflow: ellipsis;white-space: nowrap;}")]
           (when-let [selector-config (:rows-selection table-configs)]
-            ;(js/console.log (str selector-config))
             [rows-selector data-atom state-atom selector-config])
           [:table.reagent-table (:table table-configs)
            (when-let [caption (:caption table-configs)]
              caption)
            [:thead (:thead table-configs)
-            (header-row-fn (:headers data) 
-                           (get-in table-configs [:table :thead :tr]) 
+            (header-row-fn (:column-model table-configs)
+                           table-configs
                            data-atom 
                            state-atom)]
            [:tbody (:tbody table-configs)
-            (rows-fn (:rows data) state-atom)]]])))))
+            (rows-fn (:rows data) state-atom table-configs)]]])))))
 


### PR DESCRIPTION
Hi

Thanks for writing this. A fully clojurescript/html table is very useful compared to wrapping react stuff...

I found a few things that needed fixing/extending: if you reorder the columns and then reload the data the columns are in the wrong place; nice to have multiple sort columns each with a distinct direction for group-by. Separation of view and data model. I tried to make these backwards-compatible, but that soon proved to be pointless (at least to me). 

The columns are now defined by a separate column model supplied via the config map. This provides reagent keys, the header text and individual sort-ability. You can put anything you want in these, because they are passed to you when cells are painted.

There is a function to provide the hiccup for the data cells and another to perform sorting. Multiple columns can now take part in the sort and each has its own direction. Separation of view and model means you no longer put the sortable information into cell metadata. The table sate includes view-to-model mapping of the column indices, which is useful for more than just tracking the sort column(s).

I've updated the README and provided a comprehensive example in dev. Hopefully everything is clear to everyone.

