### PR TITLE
Added Fixed Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,19 +81,25 @@ from sorting. Select multiple columns for sorting by using ctrl-click. Repeat
 to toggle the sort direction.
 
 `:table` The attributes applied to the `[:table ... ]` element. Defaults
-to `{:style {:width nil}}}`
+to `{:style {:width nil}}}` If using fixed headers include `:border-collapse "separate"`
+to ensure any border on the header cells remains fixed to them.
 
-`:thead` the attributes applied to `[:thead ...]`
+`:table-container` Attributes applied to the `<div>` used to contain the table. For example
+if you want a decorative border place it here, so that any scrolling does not affect it.
+Internally, this container has the class `reagent-table-container` so you may style it
+externally.
 
-`:tbody` the attributes applied to `[:tbody ...]`
+`:thead` The attributes applied to `[:thead ...]`
 
-`:caption` an optional hiccup form for a caption
+`:tbody` The attributes applied to `[:tbody ...]`
+
+`:caption` An optional hiccup form for a caption
 
 `:scroll-height` If present then expresses a height for table and enables
 scrolling with fixed headers. Depending on what else is in the window, a
 value of `"80vh"` might give a good result. Does not play well with `:caption`.
 
-`:column-selection` optional attributes to display visible column toggles
+`:column-selection` Optional attributes to display visible column toggles
 for example `{:ul {:li {:class "btn"}}}`
 
 See `reagent-table.dev` for a working example.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ to `{:style {:width nil}}}`
 
 `:caption` an optional hiccup form for a caption
 
+`:scroll-height` If present then expresses a height for table and enables
+scrolling with fixed headers. Depending on what else is in the window, a
+value of `"80vh"` might give a good result. Does not play well with `:caption`.
+
 `:column-selection` optional attributes to display visible column toggles
 for example `{:ul {:li {:class "btn"}}}`
 

--- a/dev/reagent_table/dev.cljs
+++ b/dev/reagent_table/dev.cljs
@@ -213,16 +213,18 @@
 (def table-state (atom {:draggable true}))
 
 (r/render-component 
- [:div.container {:style {:font-size 16 :margin-top 10}}
+ [:div.container {:style {:font-size 16 :margin-top 10} :height "100%"}
   ;[:div.panel.panel-default
    ;[:div.panel-body
     [rt/reagent-table table-data {:table {:class "table table-hover table-striped table-bordered table-transition"}
+                                  :th {:style {:background-color "black"}}
                                   :table-state  table-state
+                                  :scroll-height "80vh"
                                   :column-model columns
                                   :row-key      row-key-fn
                                   :render-cell  cell-fn
                                   :sort         sort-fn
-                                  :caption [:caption "Test caption"]
+                                  ;:caption [:caption "Test caption"]
                                   :column-selection {:ul
                                                    {:li {:class "btn"}}}
                                   }]]

--- a/dev/reagent_table/dev.cljs
+++ b/dev/reagent_table/dev.cljs
@@ -216,8 +216,11 @@
  [:div.container {:style {:font-size 16 :margin-top 10} :height "100%"}
   ;[:div.panel.panel-default
    ;[:div.panel-body
-    [rt/reagent-table table-data {:table {:class "table table-hover table-striped table-bordered table-transition"}
-                                  :th {:style {:background-color "black"}}
+    [rt/reagent-table table-data {:table {:class "table table-hover table-striped table-bordered table-transition"
+                                          :style {:border-spacing 0
+                                                  :border-collapse "separate"}}
+                                  :table-container {:style {:border "1px solid green"}}
+                                  :th {:style {:border "1px solid white" :background-color "black"}}
                                   :table-state  table-state
                                   :scroll-height "80vh"
                                   :column-model columns

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.frozenlock/reagent-table "0.1.4-SNAPSHOT"
+(defproject org.clojars.frozenlock/reagent-table "0.1.5-SNAPSHOT"
   :description "FIXME: write this!"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"

--- a/src/reagent_table/core.cljs
+++ b/src/reagent_table/core.cljs
@@ -43,9 +43,11 @@
   (let [scroller    (.-currentTarget event)
         cur         (.-scrollTop scroller)
         view-height (.-clientHeight scroller)
+        cell        (.querySelector scroller "td")
         scroll-dist (if page view-height
-                             (-> (.querySelector scroller "td")
-                                 (.-clientHeight)))]
+                             (or (and cell
+                                      (.-clientHeight cell))
+                                 0))]
     (.preventDefault event)
     (set! (.-scrollTop scroller)
           (+ cur (* scroll-dist direction)))))

--- a/src/reagent_table/core.cljs
+++ b/src/reagent_table/core.cljs
@@ -24,8 +24,32 @@
     (reset! drag-end-atom drag-end)
     (events/listen js/window EventType.MOUSEMOVE drag-move)
     (events/listen js/window EventType.MOUSEUP drag-end)))
-  
 
+; See https://stackoverflow.com/questions/673153/html-table-with-fixed-headers
+(defn- table-scroll
+  "Handler for scrolling events from the table's containing div.
+  Keep the position of the headers apparently fixed while the div
+  is scrolled. Moves <thead>. May be needs to move all <th> for IE..."
+  [e]
+  ;(.log js/console (str "scrolling: " e))
+  (let [scroller (.-target e)
+        translate (str "translate(0," (.-scrollTop scroller) "px)")
+        ;all-th (.querySelectorAll scroller "th")
+        thead (.querySelector scroller "thead")]
+    ;(doseq [th (array-seq all-th)]  ; may be these for IE ?
+    ;  (set! (-> th .-style .-transform) translate))
+    (set! (-> thead .-style .-transform) translate)))
+
+(defn- init-scrolling
+  [scroller]
+  (let [container (r/dom-node scroller)]
+    (events/listen container EventType.SCROLL table-scroll)))
+
+(defn- stop-scrolling
+  [scroller]
+  (let [container (r/dom-node scroller)]
+    (.log js/console (str "stop-scroll: " container))
+    (events/unlisten container EventType.SCROLL)))
 
 (defn- recursive-merge
   "Recursively merge hash maps."
@@ -156,15 +180,11 @@
                         (when sort-fn
                           (reset! data-atom (sort-fn @data-atom
                                                      column-model
-                                                     (:sorting (update-sort-columns! model-col state-atom append)))))
-                        (.log js/console (str "append: " append))
-                        (.log js/console (str "sorting: " (:sorting @state-atom)))
-                        )]
+                                                     (:sorting (update-sort-columns! model-col state-atom append))))))]
     [:th
      (recursive-merge
       (:th config)
-      {;:width (str (get @col-state-a :width) "px") ;; <--------
-       :draggable draggable
+      {:draggable draggable
        :on-drag-start #(do (doto (.-dataTransfer %)
                              (.setData "text/plain" "")) ;; for Firefox
                            (swap! state-atom assoc :col-reordering true))
@@ -176,7 +196,8 @@
                        (swap! state-atom assoc
                               :col-hover nil
                               :col-reordering nil))
-       :style (merge {:position "relative"
+       :style (merge (get-in config [:th :style])
+                     {:position "relative"
                       :cursor (if draggable "move" nil)
                       :display (when (get col-hidden model-col) "none")}
                      (when (and (:col-reordering state)
@@ -262,6 +283,23 @@
   [headers]
   (into [] (map-indexed (fn [idx _] idx) headers)))
 
+(defn- the-table
+  [config column-model data-atom state-atom]
+  (let [scroll-height (:scroll-height config)]
+    (r/create-class {:component-did-mount (fn [this] (init-scrolling this))
+                     :component-will-unmount (fn [this] (stop-scrolling this))
+                     :reagent-render      (fn [] [:div (when scroll-height {:style {:height scroll-height :overflow "auto"}})
+                                                  [:table.reagent-table (:table config)
+                                                   (when-let [caption (:caption config)]
+                                                     caption)
+                                                   [:thead (:thead config)
+                                                    (header-row-fn column-model
+                                                                   config
+                                                                   data-atom
+                                                                   state-atom)]
+                                                   [:tbody (:tbody config)
+                                                    (rows-fn @data-atom state-atom config)]]])})))
+
 (defn reagent-table
   "Create a table, rendering the vector held in data-atom and
   configured using the map config. The minimum requirements of
@@ -327,21 +365,11 @@
             "Must provide :column-model and :render-cell in table config")
     (swap! state-atom assoc :col-index-to-model (init-column-index column-model))
     (fn []
-      (let [data @data-atom]
         [:div
          [:style (str ".reagent-table * table {table-layout:fixed;}"
                       ".reagent-table * td { max-width: 3px;"
                       "overflow: hidden;text-overflow: ellipsis;white-space: nowrap;}")]
          (when-let [selector-config (:column-selection config)]
            [column-selector state-atom selector-config column-model])
-         [:table.reagent-table (:table config)
-          (when-let [caption (:caption config)]
-            caption)
-          [:thead (:thead config)
-           (header-row-fn column-model
-                          config
-                          data-atom
-                          state-atom)]
-          [:tbody (:tbody config)
-           (rows-fn data state-atom config)]]]))))
+         [the-table config column-model data-atom state-atom]])))
 


### PR DESCRIPTION
If the configuration option `:scroll-height` in some CSS units is present the table region will scroll within that size and the headers will be maintained in a fixed position using a translation. The value of `"80vh"` works well in the demo.
