### PR TITLE
Fix for reagent 1.0 compatibility

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
 
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/clojurescript "1.9.671"]
-                 [reagent "0.7.0"]]
+                 [reagent "1.0.0"]]
 
   :plugins [[lein-cljsbuild "1.1.5"]
             [lein-figwheel "0.5.11"]]
@@ -14,7 +14,7 @@
   :source-paths ["src"]
 
   :clean-targets ^{:protect false} ["resources/public/js/compiled" "target"]
-  
+
   :cljsbuild {
     :builds [{:id "dev"
               :source-paths ["src" "dev"]
@@ -29,12 +29,12 @@
              {:id "min"
               :source-paths ["src"]
               :compiler {:output-to "resources/public/js/compiled/reagent_table.js"
-                         :main reagent-table.core                         
+                         :main reagent-table.core
                          :optimizations :advanced
                          :pretty-print false}}]}
 
   :figwheel {
-             ;; :http-server-root "public" ;; default and assumes "resources" 
+             ;; :http-server-root "public" ;; default and assumes "resources"
              ;; :server-port 3449 ;; default
              :css-dirs ["resources/public/css"] ;; watch and update CSS
 
@@ -60,5 +60,5 @@
              ;; :repl false
 
              ;; to configure a different figwheel logfile path
-             ;; :server-logfile "tmp/logs/figwheel-logfile.log" 
+             ;; :server-logfile "tmp/logs/figwheel-logfile.log"
              })

--- a/src/reagent_table/core.cljs
+++ b/src/reagent_table/core.cljs
@@ -1,5 +1,6 @@
 (ns reagent-table.core
     (:require [reagent.core :as r]
+              [reagent.dom :as rdom]
               [goog.events :as events])
     (:import [goog.events EventType]))
 
@@ -76,7 +77,7 @@
 
 (defn- init-scrolling
   [scroller]
-  (let [container (r/dom-node scroller)]
+  (let [container (rdom/dom-node scroller)]
     ;    (events/listen container EventType.SCROLL table-scroll) ;leave behind in case switch to goog events
     ;    ;(events/listen container EventType.WHEEL table-scroll)
     (.addEventListener container "scroll" table-scroll false)
@@ -145,7 +146,7 @@
                   ;:background-color "black" ;; for debug
                   }
           :on-click #(.stopPropagation %)
-          :on-mouse-down #(let [cell-node (r/dom-node cell-container)
+          :on-mouse-down #(let [cell-node (rdom/dom-node cell-container)
                                 init-x (.-clientX %)
                                 init-width (.-clientWidth cell-node)]
                             (dragging
@@ -284,7 +285,7 @@
                     (or
                       col-model
                       row)))]))
-  
+
 (defn- rows-fn [rows state-atom config]
   (let [row-key-fn (:row-key config (fn [row row-num] row-num))]
   (doall (map-indexed


### PR DESCRIPTION
Thanks for this library, it still works with latest versions of react+reagent! Just needs a little fix to require dom utilities from the new reagent namespace.